### PR TITLE
Fix random integer generation

### DIFF
--- a/znrnd/agents/approximate_maximum_entropy.py
+++ b/znrnd/agents/approximate_maximum_entropy.py
@@ -118,8 +118,8 @@ class ApproximateMaximumEntropy(Agent):
         max_index = int(len(self.data_generator) - 1)
 
         rng = jax.random.PRNGKey(onp.random.randint(684518))
-        samples = jax.random.randint(
-            rng, shape=(self.samples, target_size), minval=0, maxval=max_index
+        samples = jax.random.choice(
+            key=rng, a=max_index, shape=(self.samples, target_size), replace=False
         )
 
         entropy_array = np.zeros(self.samples)

--- a/znrnd/agents/random.py
+++ b/znrnd/agents/random.py
@@ -58,7 +58,7 @@ class RandomAgent(Agent):
         rng = jax.random.PRNGKey(onp.random.randint(1981))
 
         indices = jax.random.choice(
-            rng, len(self.data_generator) - 1, shape=(n_points,), replace=False
+            key=rng, a=len(self.data_generator) - 1, shape=(n_points,), replace=False
         )
 
         return indices

--- a/znrnd/data/data_generator.py
+++ b/znrnd/data/data_generator.py
@@ -76,12 +76,11 @@ class DataGenerator(metaclass=abc.ABCMeta):
             indices = np.linspace(0, len(self.data_pool) - 1, n_points, dtype=int)
         elif method == "random":
             key = jax.random.PRNGKey(3)
-            indices = jax.random.randint(
+            indices = jax.random.choice(
                 key=key,
+                a=len(self.data_pool) - 1,
                 shape=(n_points,),
-                minval=0,
-                maxval=len(self.data_pool) - 1,
-                dtype=int,
+                replace=False,
             )
         elif method == "first":
             indices = [i for i in range(n_points)]

--- a/znrnd/models/flax_model.py
+++ b/znrnd/models/flax_model.py
@@ -345,8 +345,7 @@ class FlaxModel(Model):
         else:
             # Prepare the shuffle.
             permutations = jax.random.permutation(self.rng, train_ds_size)
-            permutations = permutations[: steps_per_epoch * batch_size]
-            permutations = permutations.reshape((steps_per_epoch, batch_size))
+            permutations = np.array_split(permutations, steps_per_epoch)
 
             # Step over items in batch.
             batch_metrics = []


### PR DESCRIPTION
Similar to #51: Use jax.random.choice instead of jax.random.randint to avoid repeating integers in the other modules as well.
Also apply Commit 7ad3db2 to the flax model.